### PR TITLE
Fix sorting of bouteilles by default and fix tri:provenance

### DIFF
--- a/app/Http/Controllers/BouteilleController.php
+++ b/app/Http/Controllers/BouteilleController.php
@@ -22,7 +22,7 @@ class BouteilleController extends Controller
 
     public function index()
     {
-        $bouteilles = Bouteille::with('userPreferences')->with('pastilleType')->paginate(20);
+        $bouteilles = Bouteille::with('userPreferences')->with('pastilleType')->orderBy('nom', 'asc')->paginate(20);
 
         $celliers = Cellier::all();
         //return $bouteilles;
@@ -180,7 +180,7 @@ class BouteilleController extends Controller
         // dd(auth()->id());
         $bouteilles = Bouteille::whereHas('userPreferences', function ($query) {
             $query->where('listeDachat', 1)->where('user_id', auth()->id());
-        })->with('userPreferences')->with('pastilleType')->paginate(20);
+        })->with('userPreferences')->with('pastilleType')->orderBy('nom', 'asc')->paginate(20);
         $celliers = Cellier::all();
         return view('bouteilles.achats', ['bouteilles' => $bouteilles, 'celliers' => $celliers]);
     }
@@ -193,7 +193,7 @@ class BouteilleController extends Controller
         // dd(auth()->id());
         $bouteilles = Bouteille::whereHas('userPreferences', function ($query) {
             $query->where('favoris', 1)->where('user_id', auth()->id());
-        })->with('userPreferences')->with('pastilleType')->paginate(20);
+        })->with('userPreferences')->with('pastilleType')->orderBy('nom', 'asc')->paginate(20);
         $celliers = Cellier::all();
         return view('bouteilles.favoris', ['bouteilles' => $bouteilles, 'celliers' => $celliers]);
     }

--- a/resources/views/components/tri-component.blade.php
+++ b/resources/views/components/tri-component.blade.php
@@ -6,8 +6,8 @@
         <select name="tri" id="tri-component">
             <option value="nom__asc">Nom</option>
             <option value="nom__desc">Nom (Desc)</option>
-            <option value="type__asc">Provenance</option>
-            <option value="type__desc">Provenance (Desc)</option>
+            <option value="pays__asc">Provenance</option>
+            <option value="pays__desc">Provenance (Desc)</option>
             <option value="prix_saq__asc">Prix</option>
             <option value="prix_saq__desc">Prix (Desc)</option>
 


### PR DESCRIPTION
Previously, the bouteilles were not sorted by default and provenance. This PR fixes the issue by adding the `orderBy` clause to the queries in the `index`, `achats`, and `favoris` methods of the `BouteilleController`. Now, the bouteilles will be sorted by `nom` in ascending order by default. Additionally, the bouteilles will be sorted by `nom` in ascending order when filtering by `listeDachat` and `favoris`. This improves the user experience and makes it easier to find and navigate through the bouteilles.

Fixes #1234